### PR TITLE
Add capability to summarize rrsets

### DIFF
--- a/draft-lenders-dns-cbor.md
+++ b/draft-lenders-dns-cbor.md
@@ -329,13 +329,13 @@ type-spec-rdata = (
   ? type-spec,
   rdata: bstr // ( domain-name ) // ( rdata-set ),
 )
-rdata-set = (
+rdata-set = ((
   is-rrset: true,
   rdata-set: [ +bstr ]
-) / (
+) // (
   is-rrset: true,
   rdata-set: [ +[ domain-name ] ],
-)
+))
 type-spec-rdata //= ( $$structured-ts-rd )
 type-spec = (
   record-type: max-uint16,


### PR DESCRIPTION
The capability to summarize resource records set was discussed in the past, but I stayed away from it so far, as it adds additional overhead. Well, we add overhead already, so lets add more overhead (but less that the overhead than duplicating TTL and type ;-)) to maybe still have it. This is my proposal to how to optionally provide summarized resource record sets.

Maybe the CDDL can be streamlined, but at the moment, I don't see how.